### PR TITLE
Bugfix: ParseXML is called statically

### DIFF
--- a/classes/XmlToJson.php
+++ b/classes/XmlToJson.php
@@ -2,7 +2,7 @@
 
 class XmlToJson {
 
-    public function ParseXML($xmlinput) {
+    public static function ParseXML($xmlinput) {
 
         $xmlinput = str_replace(array("\n", "\r", "\t"), '', $xmlinput);
 


### PR DESCRIPTION
Default format is XML, but after switching to JSON this error fired up.
