### PR TITLE
Suppress fsockopen errors and throw correct Exceptions.

### DIFF
--- a/src/bolcom/Request.php
+++ b/src/bolcom/Request.php
@@ -53,9 +53,9 @@ class Request
         }
         $headers .= "\r\n";
 
-        $socket = fsockopen('ssl://api.bol.com', '443', $errno, $errstr, 30);
+        $socket = @fsockopen('ssl://api.bol.com', '443', $errno, $errstr, 30);
         if (!$socket) {
-            throw new Exception("{$errstr} ({$errno})");
+            throw new \Exception("{$errstr} ({$errno})");
         }
 
         $opts = array(


### PR DESCRIPTION
Due to the ssl problems of earlier this morning, we found out that exceptions did not work.
Any thoughts?