### PR TITLE
Fixed namespace & added default thumb image URL

### DIFF
--- a/src/BolCom/BasketItemProduct.php
+++ b/src/BolCom/BasketItemProduct.php
@@ -63,7 +63,7 @@ class BasketItemProduct
     {
         if ($this->thumbnailurl == "") {
             // Use a default bol.com image
-            $sThumbnailurl = DEFAULT_PRODUCT_IMAGE;
+            $sThumbnailurl = "https://s.s-bol.com/nl/static/images/main/noimage_124x100default.gif";
         } else
             $sThumbnailurl = $this->thumbnailurl;
         return $sThumbnailurl;

--- a/src/BolCom/Product.php
+++ b/src/BolCom/Product.php
@@ -50,7 +50,7 @@ class Product
     {
         if ($this->thumbnailurl == "") {
             // Use a default bol.com image
-            $sThumbnailurl = DEFAULT_PRODUCT_IMAGE;
+            $sThumbnailurl = "https://s.s-bol.com/nl/static/images/main/noimage_124x100default.gif";
         } else
             $sThumbnailurl = $this->thumbnailurl;
         return $sThumbnailurl;

--- a/src/BolCom/Request.php
+++ b/src/BolCom/Request.php
@@ -87,7 +87,7 @@ class Request
         $json_request = (json_decode($body) != NULL) ? true : false;
 
         if (!$json_request) {
-            if (strpos($body, "<?xml") === false) $body_return = $body; else $body_return = new SimpleXMLElement($body);
+            if (strpos($body, "<?xml") === false) $body_return = $body; else $body_return = new \SimpleXMLElement($body);
         } else {
             $body_return = json_decode($body);
         }


### PR DESCRIPTION
The SimpleXmlElement was put in the Bolcom namespace and could not be found when the library is autoloaded.
Added default thumb image URL (actually: replaced non-existing const in two classes)